### PR TITLE
Logging salesforce API error message.

### DIFF
--- a/src/main/java/org/embulk/output/SalesforceOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SalesforceOutputPlugin.java
@@ -7,6 +7,7 @@ import com.sforce.soap.partner.GetUserInfoResult;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.soap.partner.SaveResult;
 import com.sforce.soap.partner.UpsertResult;
+import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.ws.ConnectionException;
 import com.sforce.ws.ConnectorConfig;
@@ -231,6 +232,8 @@ public class SalesforceOutputPlugin
                     this.action(this.records);
                     logger.info("Number of processed records: {}", this.numOfSuccess + this.numOfError);
                 }
+            } catch (ApiFault ex) {
+                logger.error("API Error: {}", ex.getExceptionMessage());
             } catch (ConnectionException ex) {
                 logger.error("Connection Error: {}", ex.getMessage());
             } catch (IOException ex) {


### PR DESCRIPTION
Despite configuration error such as an invalid column name, message "Connection Error: null" is logged.
Then, I updated to log salesforce API error message.

Before

```
2015-06-25 23:59:50.367 +0900 [INFO] (transaction): {done:  0 / 1, running: 0}
2015-06-25 23:59:50.584 +0900 [ERROR] (task-0000): Connection Error: null
2015-06-25 23:59:50.585 +0900 [INFO] (transaction): {done:  1 / 1, running: 0}
```

After

```
2015-06-25 23:58:29.120 +0900 [INFO] (transaction): {done:  0 / 1, running: 0}
2015-06-25 23:58:29.357 +0900 [ERROR] (task-0000): API Error: No such column 'Xxx__c' on entity 'Yyy__c'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.
2015-06-25 23:58:29.357 +0900 [INFO] (transaction): {done:  1 / 1, running: 0}
```

（英語が自信ないので日本語で）
Salesforce側にない不正な項目名を設定した場合などに、エラーメッセージ でも「Connection Error: null」として出力されてしまうので、Salesforce APIが返すエラーメッセージを出力するようにしました。
