### PR TITLE
Enable to specify column name with relation object's external id

### DIFF
--- a/src/main/java/org/embulk/output/SalesforceOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SalesforceOutputPlugin.java
@@ -211,7 +211,7 @@ public class SalesforceOutputPlugin
                         }
                         @Override
                         public void longColumn(Column column) {
-                            record.addField(column.getName(), pageReader.getLong(column));
+                            columnWithReferenceCheck(column.getName(), pageReader.getLong(column));
                         }
                         @Override
                         public void booleanColumn(Column column) {

--- a/src/main/java/org/embulk/output/SalesforceOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SalesforceOutputPlugin.java
@@ -193,7 +193,7 @@ public class SalesforceOutputPlugin
                     pageReader.getSchema().visitColumns(new ColumnVisitor() {
                         @Override
                         public void doubleColumn(Column column) {
-                            record.addField(column.getName(), pageReader.getDouble(column));
+                            columnWithReferenceCheck(column.getName(), pageReader.getDouble(column));
                         }
                         @Override
                         public void timestampColumn(Column column) {
@@ -207,7 +207,7 @@ public class SalesforceOutputPlugin
                         }
                         @Override
                         public void stringColumn(Column column) {
-                            record.addField(column.getName(), pageReader.getString(column));
+                            columnWithReferenceCheck(column.getName(), pageReader.getString(column));
                         }
                         @Override
                         public void longColumn(Column column) {
@@ -217,7 +217,22 @@ public class SalesforceOutputPlugin
                         public void booleanColumn(Column column) {
                             record.addField(column.getName(), pageReader.getBoolean(column));
                         }
-                        
+
+                        private void columnWithReferenceCheck(String name, Object value) {
+                            if (name.indexOf('.') > 0) {
+                                String[] tokens = name.split("\\.");
+                                String referencesFieldName = tokens[0];
+                                String externalIdFieldName = tokens[1];
+
+                                SObject sObjRef = new SObject();
+                                sObjRef.setType(referencesFieldName.replaceAll("__(r|R)", "__c"));
+                                sObjRef.addField(externalIdFieldName, value);
+                                record.addField(referencesFieldName, sObjRef);
+                            } else {
+                                record.addField(name, value);
+                            }
+                        }
+
                     });
                     this.records.add(record);
                     


### PR DESCRIPTION
I extended column name configuration.
Enable to work column name with relation object's external id (e.g. `Parent__r.SomeExternalId__c` ).

主従関係や参照関係にある親オブジェクトの外部IDを指定してデータ連携できるようにしました。
